### PR TITLE
Assembly Orders Flag Check

### DIFF
--- a/tap_zoho_inventory/client.py
+++ b/tap_zoho_inventory/client.py
@@ -10,7 +10,7 @@ from datetime import timedelta, datetime, timezone
 from time import sleep
 from pathlib import Path
 from pendulum import parse
-from typing import Any, Callable, Iterable, cast, Optional, Dict
+from typing import Any, Callable, Iterable, cast
 
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 from singer_sdk.pagination import BaseAPIPaginator  # noqa: TCH002


### PR DESCRIPTION
# Add sync_assembly_orders configuration

## Changes
- Added `sync_assembly_orders` configuration option to control assembly orders sync
- Implemented default behavior to sync assembly orders if not explicitly disabled
- Added sync check in base `ZohoInventoryStream` class to handle assembly orders sync configuration

## Behavior
- When `sync_assembly_orders: false` in config, assembly orders sync is skipped
- When `sync_assembly_orders: true` or not set, assembly orders sync proceeds normally
- Other streams continue to sync regardless of this configuration

## Testing
- Verified assembly orders sync is skipped when disabled in config
- Confirmed default behavior (True) works when config is not set
- Validated other streams continue to sync normally