### PR TITLE
Add transferorders.READ to OAuth scopes

### DIFF
--- a/tap_zoho_inventory/auth.py
+++ b/tap_zoho_inventory/auth.py
@@ -52,5 +52,5 @@ class ZohoInventoryAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
         return cls(
             stream=stream,
             auth_endpoint=auth_endpoint,
-            oauth_scopes="ZohoInventory.salesorders.READ,ZohoInventory.contacts.READ,ZohoInventory.items.READ,ZohoInventory.purchaseorders.READ,ZohoInventory.purchasereceives.READ,ZohoInventory.settings.READ,ZohoInventory.compositeitems.READ",
+            oauth_scopes="ZohoInventory.salesorders.READ,ZohoInventory.contacts.READ,ZohoInventory.items.READ,ZohoInventory.purchaseorders.READ,ZohoInventory.purchasereceives.READ,ZohoInventory.settings.READ,ZohoInventory.compositeitems.READ,ZohoInventory.transferorders.READ",
         )

--- a/tap_zoho_inventory/schemas/transfer_orders_details_schema.json
+++ b/tap_zoho_inventory/schemas/transfer_orders_details_schema.json
@@ -1,0 +1,86 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "transfer_order_id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "transfer_order_number": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "date": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "from_location_id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "from_location_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "to_location_id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "to_location_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "status": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "is_intransit_order": {
+            "type": [
+                "boolean",
+                "null"
+            ]
+        },
+        "notes": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "line_items": {
+            "type": [
+                "null",
+                "array"
+            ]
+        },
+        "created_time": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "last_modified_time": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_zoho_inventory/schemas/transfer_orders_schema.json
+++ b/tap_zoho_inventory/schemas/transfer_orders_schema.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "transfer_order_id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "transfer_order_number": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "date": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "from_location_id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "from_location_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "to_location_id": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "to_location_name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "status": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "is_intransit_order": {
+            "type": [
+                "boolean",
+                "null"
+            ]
+        },
+        "created_time": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "last_modified_time": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        }
+    }
+}

--- a/tap_zoho_inventory/streams.py
+++ b/tap_zoho_inventory/streams.py
@@ -228,7 +228,7 @@ class TransferOrdersStream(ZohoInventoryStream):
 
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """Get records from the API."""
-        sync_transfer_orders = self.config.get("sync_transfer_orders", False)
+        sync_transfer_orders = self.config.get("sync_transfer_orders", True)
         if not sync_transfer_orders:
             self.logger.info("Transfer orders sync is disabled in config. Skipping sync.")
             return []

--- a/tap_zoho_inventory/streams.py
+++ b/tap_zoho_inventory/streams.py
@@ -215,4 +215,47 @@ class AssemblyOrdersDetailsStream(ZohoInventoryStream):
     def parse_response(self, response):
         for record in extract_jsonpath(self.records_jsonpath, input=response.json()):
             record = self.move_custom_fields_to_root(record)
-            yield record    
+            yield record
+
+
+class TransferOrdersStream(ZohoInventoryStream):
+    name = "transfer_orders"
+    path = "/transferorders"
+    records_jsonpath = "$.transfer_orders[*]"
+    replication_key = "last_modified_time"
+    schema_filepath = SCHEMAS_DIR / "transfer_orders_schema.json"
+    has_lines = False
+
+    def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
+        """Get records from the API."""
+        sync_transfer_orders = self.config.get("sync_transfer_orders", False)
+        if not sync_transfer_orders:
+            self.logger.info("Transfer orders sync is disabled in config. Skipping sync.")
+            return []
+
+        return super().get_records(context)
+
+    def post_process(self, row, context):
+        row_last_mod_time = parse(row["last_modified_time"])
+        if row_last_mod_time > self.get_starting_time(context):
+            return super().post_process(row, context)
+
+        return None
+
+    def get_child_context(self, record, context):
+        """Return a child context object for a given record."""
+        return {
+            "transfer_order_id": record["transfer_order_id"],
+        }
+
+
+class TransferOrderDetailsStream(ZohoInventoryStream):
+    name = "transfer_orders_details"
+    path = "/transferorders/{transfer_order_id}"
+    parent_stream_type = TransferOrdersStream
+    records_jsonpath = "$.transfer_order[*]"
+    schema_filepath = SCHEMAS_DIR / "transfer_orders_details_schema.json"
+
+    def parse_response(self, response):
+        for record in extract_jsonpath(self.records_jsonpath, input=response.json()):
+            yield record


### PR DESCRIPTION
Adds `ZohoInventory.transferorders.READ` to the OAuth scopes in auth.py.

Without this scope, the `/transferorders` endpoint returns 401. Tenants need to re-authorize after deploy to pick up the new scope.