### PR TITLE
fix: add transferorders.READ OAuth scope

### DIFF
--- a/tap_zoho_inventory/auth.py
+++ b/tap_zoho_inventory/auth.py
@@ -52,5 +52,5 @@ class ZohoInventoryAuthenticator(OAuthAuthenticator, metaclass=SingletonMeta):
         return cls(
             stream=stream,
             auth_endpoint=auth_endpoint,
-            oauth_scopes="ZohoInventory.salesorders.READ,ZohoInventory.contacts.READ,ZohoInventory.items.READ,ZohoInventory.purchaseorders.READ,ZohoInventory.purchasereceives.READ,ZohoInventory.settings.READ,ZohoInventory.compositeitems.READ",
+            oauth_scopes="ZohoInventory.salesorders.READ,ZohoInventory.contacts.READ,ZohoInventory.items.READ,ZohoInventory.purchaseorders.READ,ZohoInventory.purchasereceives.READ,ZohoInventory.settings.READ,ZohoInventory.compositeitems.READ,ZohoInventory.transferorders.READ",
         )


### PR DESCRIPTION
Adds `ZohoInventory.transferorders.READ` to the OAuth scopes in the token refresh request. Without this, the `transfer_orders` stream (added in #55) returns a 401.